### PR TITLE
Parallelism between min max

### DIFF
--- a/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
+++ b/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
@@ -752,66 +752,58 @@ namespace SSD_Components
 		unsigned int index;
 		switch (domain->ZoneAllocationScheme) {
 			case Zone_Allocation_Scheme_Type::CDPW:
-				if (domain->Channel_No_Per_Zone > 1) {	// one zone is spread to two channels at least
-					if (domain->Channel_No_Per_Zone == channel_count && 
-						domain->Chip_No_Per_Zone == chip_no_per_channel && 
-						domain->Die_No_Per_Zone == die_no_per_chip && 
-						domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
-							std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
-							//blockID = zoneOffset / block_size_in_byte;
-							pageID = zoneOffset ;
-							
-							index = pageID;
-							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
-							// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
-							// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
-							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
-							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
-						} else { // any parallelism between max and min by Chai
-							std::cout << "chai -  CDPW("
-									<< domain->Channel_No_Per_Zone
-									<< domain->Die_No_Per_Zone
-									<< domain->Plane_No_Per_Zone
-									<< domain->Chip_No_Per_Zone
-									<< ") parallelism in one zone" << std::endl;
-							pageID = zoneOffset ;
-							
-							index = pageID;
-							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
-							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
-							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
-							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
-							std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
-							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
-							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
-						}
-				}
-				else if (domain->Chip_No_Per_Zone > 1) {
+				if (domain->Channel_No_Per_Zone == channel_count && 
+					domain->Chip_No_Per_Zone == chip_no_per_channel && 
+					domain->Die_No_Per_Zone == die_no_per_chip && 
+					domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
+						std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
+						
+						index = zoneOffset;
+						targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+						targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+						targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+						targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
+						// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
+						// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
+						targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
+						targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
 
-				} 
-				else if (domain->Die_No_Per_Zone > 1) {
-
-				}
-				else if (domain->Plane_No_Per_Zone > 1) {
-
-				}
-				else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1, we will use only one channel, one chip, one die, one plane. That means, one zone's subzone and blocks are contiguous in one plane. 
-					//std::cout << "nysong - This it the minimum parallelism in one zone" << std::endl;
+				} else { // any parallelism between max and min by Chai
+					// std::cout << "chai -  CDPW("
+					// 		<< domain->Channel_No_Per_Zone
+					// 		<< domain->Die_No_Per_Zone
+					// 		<< domain->Plane_No_Per_Zone
+					// 		<< domain->Chip_No_Per_Zone
+					// 		<< ") parallelism in one zone" << std::endl;
 					
-					blockID = zoneOffset / pages_no_per_block;
-					pageID = zoneOffset % pages_no_per_block;
-
-					index = zoneID;
-					targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-					targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-					targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-					targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
-					//targetAddress.BlockID = (unsigned int)((zoneID / total_level) + blockID);
-					targetAddress.BlockID = (unsigned int) blockID;
-					targetAddress.PageID = pageID;
+					index = zoneOffset;
+					targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
+					targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
+					targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
+					targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
+					//std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
+					targetAddress.BlockID = (unsigned int)((lpn / zone_p_level) / pages_no_per_block);
+					targetAddress.PageID = (unsigned int)((lpn / zone_p_level) % pages_no_per_block);
+					//std::cout <<"Block/Page="<<targetAddress.BlockID<<","<<targetAddress.PageID<<std::endl;
+				
+					// kept original code for min parallelism
+					//std::cout << "nysong - This it the minimum parallelism in one zone" << std::endl;
+					// index = zoneID;
+					// targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+					// targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+					// targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+					// targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
+					// std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
+					
+					//targetAddress.BlockID = (unsigned int) zoneOffset / pages_no_per_block;
+					// testing above line
+					// unsigned tmp = (unsigned int) zoneOffset / pages_no_per_block;
+					// if(tmp!=targetAddress.BlockID)
+					// 	PRINT_ERROR("cannot reuse blockid calculation"); //error when lpn=512, block no should be 2.
+					// unsigned tmp2 = zoneOffset % pages_no_per_block;
+					// if(tmp2!=targetAddress.PageID)
+					// 	PRINT_ERROR("cannot reuse pageid calculation"); // never enters
+					//std::cout <<"Block/Page="<<targetAddress.BlockID<<","<<targetAddress.PageID<<std::endl;
 				}
 				break;
 			default:

--- a/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
+++ b/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
@@ -752,58 +752,66 @@ namespace SSD_Components
 		unsigned int index;
 		switch (domain->ZoneAllocationScheme) {
 			case Zone_Allocation_Scheme_Type::CDPW:
-				if (domain->Channel_No_Per_Zone == channel_count && 
-					domain->Chip_No_Per_Zone == chip_no_per_channel && 
-					domain->Die_No_Per_Zone == die_no_per_chip && 
-					domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
-						std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
-						
-						index = zoneOffset;
-						targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-						targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-						targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-						targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
-						// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
-						// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
-						targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
-						targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
+				if (domain->Channel_No_Per_Zone > 1) {	// one zone is spread to two channels at least
+					if (domain->Channel_No_Per_Zone == channel_count && 
+						domain->Chip_No_Per_Zone == chip_no_per_channel && 
+						domain->Die_No_Per_Zone == die_no_per_chip && 
+						domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
+							std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
+							//blockID = zoneOffset / block_size_in_byte;
+							pageID = zoneOffset ;
+							
+							index = pageID;
+							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
+							// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
+							// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
+							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
+							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
+						} else { // any parallelism between max and min by Chai
+							std::cout << "chai -  CDPW("
+									<< domain->Channel_No_Per_Zone
+									<< domain->Die_No_Per_Zone
+									<< domain->Plane_No_Per_Zone
+									<< domain->Chip_No_Per_Zone
+									<< ") parallelism in one zone" << std::endl;
+							pageID = zoneOffset ;
+							
+							index = pageID;
+							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
+							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
+							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
+							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
+							std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
+							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
+							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
+						}
+				}
+				else if (domain->Chip_No_Per_Zone > 1) {
 
-				} else { // any parallelism between max and min by Chai
-					// std::cout << "chai -  CDPW("
-					// 		<< domain->Channel_No_Per_Zone
-					// 		<< domain->Die_No_Per_Zone
-					// 		<< domain->Plane_No_Per_Zone
-					// 		<< domain->Chip_No_Per_Zone
-					// 		<< ") parallelism in one zone" << std::endl;
-					
-					index = zoneOffset;
-					targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
-					targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
-					targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
-					targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
-					//std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
-					targetAddress.BlockID = (unsigned int)((lpn / zone_p_level) / pages_no_per_block);
-					targetAddress.PageID = (unsigned int)((lpn / zone_p_level) % pages_no_per_block);
-					//std::cout <<"Block/Page="<<targetAddress.BlockID<<","<<targetAddress.PageID<<std::endl;
-				
-					// kept original code for min parallelism
+				} 
+				else if (domain->Die_No_Per_Zone > 1) {
+
+				}
+				else if (domain->Plane_No_Per_Zone > 1) {
+
+				}
+				else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1, we will use only one channel, one chip, one die, one plane. That means, one zone's subzone and blocks are contiguous in one plane. 
 					//std::cout << "nysong - This it the minimum parallelism in one zone" << std::endl;
-					// index = zoneID;
-					// targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-					// targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-					// targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-					// targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
-					// std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
 					
-					//targetAddress.BlockID = (unsigned int) zoneOffset / pages_no_per_block;
-					// testing above line
-					// unsigned tmp = (unsigned int) zoneOffset / pages_no_per_block;
-					// if(tmp!=targetAddress.BlockID)
-					// 	PRINT_ERROR("cannot reuse blockid calculation"); //error when lpn=512, block no should be 2.
-					// unsigned tmp2 = zoneOffset % pages_no_per_block;
-					// if(tmp2!=targetAddress.PageID)
-					// 	PRINT_ERROR("cannot reuse pageid calculation"); // never enters
-					//std::cout <<"Block/Page="<<targetAddress.BlockID<<","<<targetAddress.PageID<<std::endl;
+					blockID = zoneOffset / pages_no_per_block;
+					pageID = zoneOffset % pages_no_per_block;
+
+					index = zoneID;
+					targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+					targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+					targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+					targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
+					//targetAddress.BlockID = (unsigned int)((zoneID / total_level) + blockID);
+					targetAddress.BlockID = (unsigned int) blockID;
+					targetAddress.PageID = pageID;
 				}
 				break;
 			default:

--- a/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
+++ b/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
@@ -757,7 +757,7 @@ namespace SSD_Components
 						domain->Chip_No_Per_Zone == chip_no_per_channel && 
 						domain->Die_No_Per_Zone == die_no_per_chip && 
 						domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
-							//std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
+							std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
 							//blockID = zoneOffset / block_size_in_byte;
 							pageID = zoneOffset ;
 							
@@ -768,7 +768,24 @@ namespace SSD_Components
 							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
 							// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
 							// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
-							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block); //TODO:can I use lpn here?
+							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
+							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
+						} else { // any parallelism between max and min by Chai
+							std::cout << "chai -  CDPW("
+									<< domain->Channel_No_Per_Zone
+									<< domain->Die_No_Per_Zone
+									<< domain->Plane_No_Per_Zone
+									<< domain->Chip_No_Per_Zone
+									<< ") parallelism in one zone" << std::endl;
+							pageID = zoneOffset ;
+							
+							index = pageID;
+							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
+							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
+							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
+							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
+							std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
+							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
 							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
 						}
 				}

--- a/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
+++ b/src/ssd/Address_Mapping_Unit_Zone_Level.cpp
@@ -752,55 +752,43 @@ namespace SSD_Components
 		unsigned int index;
 		switch (domain->ZoneAllocationScheme) {
 			case Zone_Allocation_Scheme_Type::CDPW:
-				if (domain->Channel_No_Per_Zone > 1) {	// one zone is spread to two channels at least
-					if (domain->Channel_No_Per_Zone == channel_count && 
-						domain->Chip_No_Per_Zone == chip_no_per_channel && 
-						domain->Die_No_Per_Zone == die_no_per_chip && 
-						domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
-							std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
-							//blockID = zoneOffset / block_size_in_byte;
-							pageID = zoneOffset ;
-							
-							index = pageID;
-							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
-							// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
-							// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
-							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
-							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
-						} else { // any parallelism between max and min by Chai
-							std::cout << "chai -  CDPW("
-									<< domain->Channel_No_Per_Zone
-									<< domain->Die_No_Per_Zone
-									<< domain->Plane_No_Per_Zone
-									<< domain->Chip_No_Per_Zone
-									<< ") parallelism in one zone" << std::endl;
-							pageID = zoneOffset ;
-							
-							index = pageID;
-							targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
-							targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
-							targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
-							targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
-							std::cout <<"Assigned CDPW="<<targetAddress.ChannelID<<targetAddress.DieID<<targetAddress.PlaneID<<targetAddress.ChipID<<std::endl;
-							targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
-							targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
-						}
-				}
-				else if (domain->Chip_No_Per_Zone > 1) {
-
-				} 
-				else if (domain->Die_No_Per_Zone > 1) {
-
-				}
-				else if (domain->Plane_No_Per_Zone > 1) {
-
-				}
-				else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1, we will use only one channel, one chip, one die, one plane. That means, one zone's subzone and blocks are contiguous in one plane. 
+				if (domain->Channel_No_Per_Zone == channel_count && 
+					domain->Chip_No_Per_Zone == chip_no_per_channel && 
+					domain->Die_No_Per_Zone == die_no_per_chip && 
+					domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
+						// std::cout << "nysong - this is the maximum parallelism in one zone" << std::endl;
+						//blockID = zoneOffset / block_size_in_byte;
+						pageID = zoneOffset ;
+						
+						index = pageID;
+						targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+						targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+						targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+						targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
+						// targetAddress.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
+						// targetAddress.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
+						//targetAddress.BlockID = (unsigned int)((lpn / total_level) / pages_no_per_block);
+						//targetAddress.PageID = (unsigned int)((lpn / total_level) % pages_no_per_block);
+				} else if (	domain->Channel_No_Per_Zone > 1 || 
+							domain->Chip_No_Per_Zone > 1 ||
+							domain->Die_No_Per_Zone > 1 ||
+							domain->Plane_No_Per_Zone > 1 ) { // any parallelism between max and min by Chai
+						// std::cout << "chai -  CDPW("
+						// 		<< domain->Channel_No_Per_Zone
+						// 		<< domain->Die_No_Per_Zone
+						// 		<< domain->Plane_No_Per_Zone
+						// 		<< domain->Chip_No_Per_Zone
+						// 		<< ") parallelism in one zone" << std::endl;
+						pageID = zoneOffset ;
+						
+						index = pageID;
+						targetAddress.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
+						targetAddress.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
+						targetAddress.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
+						targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
+				} else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1, we will use only one channel, one chip, one die, one plane. That means, one zone's subzone and blocks are contiguous in one plane. 
 					//std::cout << "nysong - This it the minimum parallelism in one zone" << std::endl;
-					
+
 					blockID = zoneOffset / pages_no_per_block;
 					pageID = zoneOffset % pages_no_per_block;
 
@@ -810,8 +798,8 @@ namespace SSD_Components
 					targetAddress.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
 					targetAddress.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
 					//targetAddress.BlockID = (unsigned int)((zoneID / total_level) + blockID);
-					targetAddress.BlockID = (unsigned int) blockID;
-					targetAddress.PageID = pageID;
+					//targetAddress.BlockID = (unsigned int) blockID;
+					//targetAddress.PageID = pageID;
 				}
 				break;
 			default:
@@ -921,45 +909,43 @@ namespace SSD_Components
 
 		switch (domain->ZoneAllocationScheme) {
 			case Zone_Allocation_Scheme_Type::CDPW:
-				if (domain->Channel_No_Per_Zone > 1) {	// one zone is spread to two channels at least
-					if (domain->Channel_No_Per_Zone == channel_count && 
-						domain->Chip_No_Per_Zone == chip_no_per_channel && 
-						domain->Die_No_Per_Zone == die_no_per_chip && 
-						domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
-							//blockID = zoneOffset / block_size_in_byte;
-							pageID = zoneOffset / page_size_in_byte;
+				if (domain->Channel_No_Per_Zone == channel_count && 
+					domain->Chip_No_Per_Zone == chip_no_per_channel && 
+					domain->Die_No_Per_Zone == die_no_per_chip && 
+					domain->Plane_No_Per_Zone == plane_no_per_die) { // maximum parallelism
+						//blockID = zoneOffset / block_size_in_byte;
+						pageID = zoneOffset / page_size_in_byte;
+						
+						index = pageID;
+						read_address.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
+						read_address.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
+						read_address.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
+						read_address.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
+				} else if (	domain->Channel_No_Per_Zone > 1 || 
+							domain->Chip_No_Per_Zone > 1 ||
+							domain->Die_No_Per_Zone > 1 ||
+							domain->Plane_No_Per_Zone > 1 ) { // any parallelism between max and min by Chai
 
-							index = pageID;
-							read_address.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
-							read_address.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
-							read_address.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
-							read_address.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)];
-							read_address.BlockID = (unsigned int)((zoneID * block_no_per_subzone) + ((pageID / total_level) / pages_no_per_block));
-							read_address.PageID = (unsigned int)((pageID / total_level) % pages_no_per_block);
-						}
-
-				}
-				else if (domain->Chip_No_Per_Zone > 1) {
-
-				} 
-				else if (domain->Die_No_Per_Zone > 1) {
-
-				}
-				else if (domain->Plane_No_Per_Zone > 1) {
-
-				}
-				else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1 
-					blockID = zoneOffset / zone_size_in_byte;
-					pageID = (zoneOffset % zone_size_in_byte) / page_size_in_byte;
+						pageID = zoneOffset ;
+						
+						index = pageID;
+						read_address.ChannelID = domain->Channel_ids[(unsigned int)(index % domain->Channel_No_Per_Zone)];
+						read_address.ChipID = domain->Chip_ids[(unsigned int)((index / (domain->Channel_No_Per_Zone * domain->Die_No_Per_Zone * domain->Plane_No_Per_Zone)) % domain->Chip_No_Per_Zone)];
+						read_address.DieID = domain->Die_ids[(unsigned int)(index / domain->Channel_No_Per_Zone % domain->Die_No_Per_Zone)];
+						read_address.PlaneID = domain->Plane_ids[(unsigned int)(index / (domain->Channel_No_Per_Zone*domain->Die_No_Per_Zone) % domain->Plane_No_Per_Zone)];
+				} else {	// 1*1*1*1 = minimum parallelism in one zone, zone_p_level is 1, we will use only one channel, one chip, one die, one plane. That means, one zone's subzone and blocks are contiguous in one plane. 
+					//blockID = zoneOffset / zone_size_in_byte;
+					// pageID = (zoneOffset % zone_size_in_byte) / page_size_in_byte;
 
 					index = zoneID;
 					read_address.ChannelID = domain->Channel_ids[(unsigned int)(index % channel_count)];
 					read_address.ChipID = domain->Chip_ids[(unsigned int)((index / (channel_count * die_no_per_chip * plane_no_per_die)) % chip_no_per_channel)];
 					read_address.DieID = domain->Die_ids[(unsigned int)(index / channel_count % die_no_per_chip)];
 					read_address.PlaneID = domain->Plane_ids[(unsigned int)(index / (channel_count*die_no_per_chip) % plane_no_per_die)]; 
-					read_address.BlockID = (unsigned int)((zoneID / total_level) + blockID);
-					read_address.PageID = pageID;
+					// read_address.BlockID = (unsigned int)((zoneID / total_level) + blockID);
+					// read_address.PageID = pageID;
 				}
+				break;
 			default:
 				PRINT_ERROR("Unknown plane allocation scheme type!")
 		}


### PR DESCRIPTION
Now parallelism has 3 cases: max, middle, min
code are in allocate_plane_for_user_write () and online_create_entry_for_reads.
Also took out code that computes BlockID and PageID
because in min parallelism, BlockID seems erroneous.
Nae Young please enable the default code to compute blockID and pageID.